### PR TITLE
Another Allegro library dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ IF(UNIX)
 				allegro_font
 				allegro_image
 				allegro_ttf
+				allegro_color
 				${PROJECT_LIBS}
 			)
 		ENDIF()


### PR DESCRIPTION
This fixes the "undefined symbol: al_color_rgb_to_hsv" error mentioned in https://github.com/DFHack/dfhack/issues/282
