### PR TITLE
Replace dfhack-tinyxml with DFHACK_TINYXML variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/../proto/RemoteFortressR
 
 SET(PROJECT_SRCS ${PROJECT_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/../proto/RemoteFortressReader.pb.cc)
 
-DFHACK_PLUGIN(stonesense ${PROJECT_SRCS} LINK_LIBRARIES dfhack-tinyxml ${PROJECT_LIBS})
+DFHACK_PLUGIN(stonesense ${PROJECT_SRCS} LINK_LIBRARIES ${DFHACK_TINYXML} ${PROJECT_LIBS})
 
 # Make sure the source is generated before the executable builds.
 ADD_DEPENDENCIES(stonesense generate_proto)


### PR DESCRIPTION
This modifies stonesense's CMakeLists to use the DFHACK_TINYXML variable set when building dfhack to either "dfhack-tinyxml" (the bundled copy of tinyxml) or "tinyxml", in which case we try to link against a copy of tinyxml present on the system.

See https://github.com/DFHack/dfhack/pull/950; I'm opening this pull request because I see that was merged. :)