### PR TITLE
include <GL/glext.h>

### DIFF
--- a/common.h
+++ b/common.h
@@ -31,6 +31,8 @@ using namespace df::enums;
 #include <allegro5/allegro_opengl.h>
 #include <allegro5/utf8.h>
 
+#include <GL/glext.h>
+
 // allegro leaks X headers, undef some of it here:
 #undef TileShape
 #undef None


### PR DESCRIPTION
this fixes `GLhandleARB` not being defined