### PR TITLE
Fix Linux build (X11 defines Status to mean int)

### DIFF
--- a/common.h
+++ b/common.h
@@ -34,6 +34,7 @@ using namespace df::enums;
 // allegro leaks X headers, undef some of it here:
 #undef TileShape
 #undef None
+#undef Status
 
 #include "commonTypes.h"
 #include "Tile.h"


### PR DESCRIPTION
Broken by RemoteFortressReader update: https://github.com/DFHack/dfhack/pull/1200