### PR TITLE
Fix some Tile memory safety issues

### DIFF
--- a/Tile.cpp
+++ b/Tile.cpp
@@ -61,89 +61,7 @@ worn_item::worn_item()
     dyematt.type = -1;
 }
 
-Tile::Tile()
-{
-    // zero out everything
-    valid = false;
-    visible = false;
-
-    ownerSegment = nullptr;
-
-    x = 0;
-    y = 0;
-    z = 0;
-    tileType = tiletype::Void;
-    material.type = 0;
-    material.index = 0;
-    layerMaterial.type = 0;
-    layerMaterial.index = 0;
-    veinMaterial.type = 0;
-    veinMaterial.index = 0;
-    hasVein = false;
-
-    depthBorderNorth = false;
-    depthBorderWest = false;
-    depthBorderDown = false;
-
-    shadow = 0;
-
-    wallborders = 0;
-    floorborders = 0;
-    openborders = 0;
-    rampborders = 0;
-    upstairborders = 0;
-    downstairborders = 0;
-    lightborders = 0;
-
-    fog_of_war = false;
-
-    rampindex = 0;
-
-    deepwater = 0;
-
-    flow_direction = tile_liquid_flow_dir::none;
-
-    designation.whole = 0;
-    occ.whole = 0;
-
-    creature = nullptr;
-    tree.type = 0;
-    tree.index = 0;
-    tree_tile.whole = 0;
-
-    mudlevel = 0;
-    snowlevel = 0;
-    bloodlevel = 0;
-    bloodcolor = al_map_rgba(0,0,0,0);
-
-    grasslevel = 0;
-    grassmat = 0;
-
-    engraving_character = 0;
-    engraving_flags.whole = 0;
-    engraving_quality = 0;
-
-    consForm = 0;
-
-    obscuringCreature = false;
-    obscuringBuilding = false;
-
-    tileeffect.matt.type = 0;
-    tileeffect.matt.index = 0;
-    tileeffect.density = 0;
-    tileeffect.type = flow_type::Miasma;
-
-    memset(&Item, 0, sizeof(Item));
-
-    building.info = nullptr;
-    building.type = building_type::Chair;
-    building.sprites.clear();
-    building.parent = nullptr;
-    building.constructed_mats.clear();
-    building.special = 0;
-}
-
-Tile::Tile(WorldSegment* segment, df::tiletype type) : Tile()
+Tile::Tile(WorldSegment* segment, df::tiletype type)
 {
     //set all the nonzero values
     valid=true;
@@ -187,18 +105,6 @@ bool Tile::IsValid()
 }
 
 /**
- * invalidates this Tile
- * returns old validity value
- */
-bool Tile::Invalidate(){
-    if(!valid) {
-        return false;
-    }
-    valid=false;
-    return true;
-}
-
-/**
  * invalidates this Tile, and frees memory of any member objects
  *  through the deconstructor
  * returns old validity value
@@ -223,6 +129,7 @@ bool Tile::CleanCreateAndValidate(Tile* dst, WorldSegment* segment, df::tiletype
     if (wasValid) {
         dst->~Tile();
     }
+    memset(dst, 0, sizeof(Tile));
     new (dst) Tile(segment, type);
     dst->valid = true;
     return wasValid;

--- a/Tile.h
+++ b/Tile.h
@@ -127,6 +127,8 @@ public:
     bool Invalidate();
     static bool InvalidateAndDestroy(Tile*);
     static bool CleanCreateAndValidate(Tile*, WorldSegment*, df::tiletype);
+
+    friend class WorldSegment;
 };
 
 void createEffectSprites();

--- a/WorldSegment.h
+++ b/WorldSegment.h
@@ -46,7 +46,11 @@ public:
 
         uint32_t newNumTiles = inState.Size.x * inState.Size.y * inState.Size.z;
         uint32_t memoryNeeded = newNumTiles * sizeof(Tile);
-        tiles = new Tile[newNumTiles];
+        tiles = (Tile *)new char[memoryNeeded];
+        //memset(tiles, 0, memoryNeeded);
+        for(uint32_t i = 0; i < newNumTiles; i++) {
+            tiles[i].valid = false;
+        }
     }
 
     ~WorldSegment() {
@@ -56,7 +60,7 @@ public:
         }
         ClearBuildings();
         ClearUnits();
-        delete[] tiles;
+        delete[] (char *)tiles;
     }
 
     void Reset(GameState inState, bool hard=false) {
@@ -72,8 +76,12 @@ public:
         uint32_t memoryNeeded = newNumTiles * sizeof(Tile);
         //if this is a hard reset, or if the size doesn't match what is needed, get a new segment
         if(hard || newNumTiles != getNumTiles()) {
-            delete[] tiles;
-            tiles = new Tile[newNumTiles];
+            delete[] (char *)tiles;
+            tiles = (Tile *)new char[memoryNeeded];
+            for(uint32_t i = 0; i < newNumTiles; i++) {
+                tiles[i].valid = false;
+            }
+            //memset(tiles, 0, memoryNeeded);
         }
 
         segState = inState;


### PR DESCRIPTION
0fb9abc5f8a7511269ab072317bbd366bc2fa9ca introduced some paths where Tile instances could be double-freed: specifically, `WorldSegment::Reset()` would call `Tile::InvalidateAndDestroy()` on individual tiles, followed by `delete[]` on the array containing them, and both of these call the Tile destructor.

Fixes an issue reported on Discord, and also fixes #73 (at least from my initial testing).

Marking as a draft because I would like to potentially revisit how Tile instances are stored. They contain at least one non-POD object (`Tile::building::sprites` is a vector, and in fact was what usually triggered the crash on my end), and the changes here _might_ result in some memory leaks if those are not freed properly.