### PR TITLE
Rework allocation and initialization of Tiles

### DIFF
--- a/Tile.cpp
+++ b/Tile.cpp
@@ -61,78 +61,101 @@ worn_item::worn_item()
     dyematt.type = -1;
 }
 
-Tile::Tile(WorldSegment* segment, df::tiletype type)
+Tile::Tile()
 {
-    //set all the nonzero values
-    valid=true;
-    visible = true;
+    valid = visible = false;
 
-    tileType = type;
+    ownerSegment = NULL;
+    creature = NULL;
+    building.info = NULL;
+    building.parent = NULL;
+}
+
+// Clear all pointers and empty all vectors
+void Tile::Reset()
+{
+    valid = visible = false;
+
+    ownerSegment = NULL;
+    creature = NULL;
+    building.info = NULL;
+    building.parent = NULL;
+
+    building.sprites.clear();
+    building.constructed_mats.clear();
+
+    tileType = df::tiletype::Void;
+    x = y = z = -30000;
+}
+
+void Tile::Attach(WorldSegment* segment, df::tiletype type, int32_t _x, int32_t _y, int32_t _z)
+{
+    const DFHack::t_matglossPair NO_MATGLOSS = { INVALID_INDEX, INVALID_INDEX };
+
+    if (valid)
+        Reset();
+
+    valid = visible = true;
+
     ownerSegment = segment;
 
-    material.type = INVALID_INDEX;
-    material.index = INVALID_INDEX;
+    x = _x;
+    y = _y;
+    z = _z;
 
+    tileType = type;
+
+    material = NO_MATGLOSS;
+    layerMaterial = NO_MATGLOSS;
+    veinMaterial = NO_MATGLOSS;
+    hasVein = false;
+
+    depthBorderNorth = depthBorderWest = depthBorderDown = false;
+
+    shadow = 0;
+
+    wallborders = floorborders = rampborders = upstairborders = downstairborders = 0;
     openborders = 255;
     lightborders = 255;
 
+    fog_of_war = false;
+
+    rampindex = 0;
+
+    deepwater = false;
+
+    flow_direction = df::tile_liquid_flow_dir::none;
+
+    designation.whole = 0;
+    occ.whole = 0;
+
+    tree = NO_MATGLOSS;
+    tree_tile.whole = 0;
+
+    mudlevel = snowlevel = bloodlevel = 0;
+    bloodcolor = al_map_rgba(0,0,0,0);
+
+    grasslevel = 0;
+    grassmat = INVALID_INDEX;
+
+    engraving_character = 0;
+    engraving_flags.whole = 0;
+    engraving_quality = 0;
+
+    consForm = 0;
+
+    obscuringCreature = obscuringBuilding = false;
+
+    tileeffect.matt = NO_MATGLOSS;
+    tileeffect.density = 0;
     tileeffect.type = (df::flow_type) INVALID_INDEX;
 
-    Item.item.type = INVALID_INDEX;
-    Item.item.index= INVALID_INDEX;
-    Item.matt.type= INVALID_INDEX;
-    Item.matt.index= INVALID_INDEX;
-    Item.dyematt.type= INVALID_INDEX;
-    Item.dyematt.index= INVALID_INDEX;
+    Item.item = NO_MATGLOSS;
+    Item.matt = NO_MATGLOSS;
+    Item.dyematt = NO_MATGLOSS;
 
-    building.type = (building_type::building_type) BUILDINGTYPE_NA;
-    //building.parent = NULL;
-    //building.info = NULL;
-}
-
-Tile::~Tile(void)
-{
-    building.info = NULL;
-}
-
-/**
- * returns the validity of this Tile
- * Tiles that are not valid have undefined behavior
- */
-bool Tile::IsValid()
-{
-    return valid;
-}
-
-/**
- * invalidates this Tile, and frees memory of any member objects
- *  through the deconstructor
- * returns old validity value
- */
-bool Tile::InvalidateAndDestroy(Tile* dst)
-{
-    if(!dst->valid) {
-        return false;
-    }
-    dst->~Tile();
-    dst->valid=false;
-    return true;
-}
-
-/**
- * creates a clean empty tile at the destination address
- * returns old validity value
- */
-bool Tile::CleanCreateAndValidate(Tile* dst, WorldSegment* segment, df::tiletype type)
-{
-    bool wasValid = dst->valid;
-    if (wasValid) {
-        dst->~Tile();
-    }
-    memset(dst, 0, sizeof(Tile));
-    new (dst) Tile(segment, type);
-    dst->valid = true;
-    return wasValid;
+    building.type = df::building_type::NONE;
+    building.special = 0;
 }
 
 inline ALLEGRO_BITMAP* imageSheet(t_SpriteWithOffset sprite, ALLEGRO_BITMAP* defaultBmp)

--- a/Tile.cpp
+++ b/Tile.cpp
@@ -129,7 +129,8 @@ void Tile::Attach(WorldSegment* segment, df::tiletype type, int32_t _x, int32_t 
     designation.whole = 0;
     occ.whole = 0;
 
-    tree = NO_MATGLOSS;
+    tree.type = 0; // this field actually holds df::plant_flags, not a material type
+    tree.index = INVALID_INDEX;
     tree_tile.whole = 0;
 
     mudlevel = snowlevel = bloodlevel = 0;
@@ -230,6 +231,9 @@ void Tile::DrawGrowth(c_sprite * spriteobject, bool top=true)
         || tileMaterial() == tiletype_material::TREE
         || tileMaterial() == tiletype_material::MUSHROOM)
     {
+        // Don't try to render a growth if there's no tree associated with it yet
+        if (tree.index == INVALID_INDEX)
+            return;
         df::plant_raw* plantRaw = df::global::world->raws.plants.all[tree.index];
         for (size_t i = 0; i < plantRaw->growths.size(); i++)
         {

--- a/Tile.h
+++ b/Tile.h
@@ -16,14 +16,12 @@ class Tile
 private:
     bool valid;
 
-    // Functions start here.
-
-    // use CleanCreateAndValidate or InvalidateAndDestroy
-    Tile(WorldSegment* ownerSegment, df::tiletype type);
-
 public:
     Tile();
-    ~Tile();
+
+    bool IsValid() { return valid; }
+    void Reset();
+    void Attach(WorldSegment*, df::tiletype, int32_t, int32_t, int32_t);
 
     bool visible;
 
@@ -122,13 +120,6 @@ public:
     void AssembleParticleCloud(int count, float centerX, float centerY, float rangeX, float rangeY, ALLEGRO_BITMAP *sprite, ALLEGRO_COLOR tint);
     void AssembleSpriteFromSheet(int spriteNum, ALLEGRO_BITMAP* spriteSheet, ALLEGRO_COLOR color, float x, float y, Tile * b=NULL, float in_scale=1.0f);
     void AssembleSprite(ALLEGRO_BITMAP *bitmap, ALLEGRO_COLOR tint, float sx, float sy, float sw, float sh, float dx, float dy, float dw, float dh, int flags);
-
-    bool IsValid();
-    bool Invalidate();
-    static bool InvalidateAndDestroy(Tile*);
-    static bool CleanCreateAndValidate(Tile*, WorldSegment*, df::tiletype);
-
-    friend class WorldSegment;
 };
 
 void createEffectSprites();

--- a/WorldSegment.cpp
+++ b/WorldSegment.cpp
@@ -92,11 +92,7 @@ Tile* WorldSegment::ResetTile(int32_t x, int32_t y, int32_t z, df::tiletype type
 
     Tile* tptr = &(tiles[index]);
 
-    Tile::InvalidateAndDestroy(tptr);
-    Tile::CleanCreateAndValidate(tptr,this,type);
-    tptr->x = x;
-    tptr->y = y;
-    tptr->z = z;
+    tptr->Attach(this, type, x, y, z);
     return tptr;
 }
 

--- a/WorldSegment.h
+++ b/WorldSegment.h
@@ -43,24 +43,15 @@ public:
         segState = inState;
         segState.Position.z = segState.Position.z - segState.Size.z + 1;
 
-
         uint32_t newNumTiles = inState.Size.x * inState.Size.y * inState.Size.z;
-        uint32_t memoryNeeded = newNumTiles * sizeof(Tile);
-        tiles = (Tile *)new char[memoryNeeded];
-        //memset(tiles, 0, memoryNeeded);
-        for(uint32_t i = 0; i < newNumTiles; i++) {
-            tiles[i].valid = false;
-        }
+        tiles = new Tile[newNumTiles]();
     }
 
     ~WorldSegment() {
-        uint32_t num = getNumTiles();
-        for(uint32_t i = 0; i < num; i++) {
-            Tile::InvalidateAndDestroy(& tiles[i]);
-        }
+        delete[] tiles;
+        tiles = NULL;
         ClearBuildings();
         ClearUnits();
-        delete[] (char *)tiles;
     }
 
     void Reset(GameState inState, bool hard=false) {
@@ -68,20 +59,18 @@ public:
         ClearBuildings();
         ClearUnits();
         todraw.clear();
-        for(uint32_t i = 0; i < getNumTiles(); i++) {
-            Tile::InvalidateAndDestroy(& tiles[i]);
-        }
 
         uint32_t newNumTiles = inState.Size.x * inState.Size.y * inState.Size.z;
-        uint32_t memoryNeeded = newNumTiles * sizeof(Tile);
         //if this is a hard reset, or if the size doesn't match what is needed, get a new segment
         if(hard || newNumTiles != getNumTiles()) {
-            delete[] (char *)tiles;
-            tiles = (Tile *)new char[memoryNeeded];
-            for(uint32_t i = 0; i < newNumTiles; i++) {
-                tiles[i].valid = false;
+            delete[] tiles;
+            tiles = new Tile[newNumTiles]();
+        }
+        else {
+            // Otherwise, reset all existing tiles to their initial state
+            for(uint32_t i = 0; i < getNumTiles(); i++) {
+                tiles[i].Reset();
             }
-            //memset(tiles, 0, memoryNeeded);
         }
 
         segState = inState;


### PR DESCRIPTION
Switch it back to using "tiles = new Tile[len]" and "delete[] tiles;", but this time just use ordinary method calls to attach/reset the tile instead of messing around with placement new and explicit destructor calls (which seemed safe on Windows but caused frequent crashes on Linux).

In essence, this is trying to accomplish what 0fb9abc5f8a7511269ab072317bbd366bc2fa9ca failed to do.