### PR TITLE
Fix a crash with pre-existing campsite

### DIFF
--- a/SpriteMaps.cpp
+++ b/SpriteMaps.cpp
@@ -12,25 +12,32 @@ using namespace df::enums;
 
 c_sprite *  GetTerrainSpriteMap(int in, t_matglossPair material, vector<std::unique_ptr<TerrainConfiguration>>& configTable, uint16_t form)
 {
-    int tempform;
-    if(form == item_type::BAR) {
-        tempform = FORM_BAR;
-    }
-    if(form == item_type::BLOCKS) {
-        tempform = FORM_BLOCK;
-    }
-    if(form == item_type::BOULDER) {
-        tempform = FORM_BOULDER;
-    }
-    if(form == item_type::WOOD) {
-        tempform = FORM_LOG;
-    }
     // in case we need to return nothing
-    static c_sprite * defaultSprite = new c_sprite;
+    static c_sprite* defaultSprite = new c_sprite;
     defaultSprite->reset();
     defaultSprite->set_sheetindex(UNCONFIGURED_INDEX);
     defaultSprite->set_fileindex(INVALID_INDEX);
     defaultSprite->set_needoutline(1);
+
+    int tempform;
+    switch (form)
+    {
+    case item_type::BAR:
+        tempform = FORM_BAR;
+        break;
+    case item_type::BLOCKS:
+        tempform = FORM_BLOCK;
+        break;
+    case item_type::BOULDER:
+        tempform = FORM_BOULDER;
+        break;
+    case item_type::WOOD:
+        tempform = FORM_LOG;
+        break;
+    default:
+        return defaultSprite;
+    }
+
     // first check the input is sane
     if( in < 0 || in >= (int)configTable.size() ) {
         return defaultSprite;


### PR DESCRIPTION
Fix a possible crash when entering `GetTerrainSpriteMap` with an unsupported form. This would leave `tempform` uninitialized, later leading to an out of bound access. At the moment the fix is to just return the default sprite.

Note: I am completely unfamiliar with the codebase, and was not able to understand this situation "in context", so maybe there is a better way to fix that.

In my crash, I had:

```
material={type=426 index=27}
form=58
```

Which would translate to the material `PLANT:FLAX:THREAD`/`linen` and form would be `CLOTH`?

On my map they come from some pre-existing campsite and crashes as soon as one of the "tent" is in sight. This change is likely a fix for #75 given how similar the situation is.
