### PR TITLE
Remove incorrect use of DFHack::Units::MAX_COLORS

### DIFF
--- a/Creatures.cpp
+++ b/Creatures.cpp
@@ -518,8 +518,8 @@ void copyCreature(df::unit * source, SS_Unit & furball)
 
     // appearance
     furball.nbcolors = source->appearance.colors.size();
-    if(furball.nbcolors > DFHack::Units::MAX_COLORS)
-        furball.nbcolors = DFHack::Units::MAX_COLORS;
+    if(furball.nbcolors > 15) // Was using DFHack::Units::MAX_COLORS for no apparent reason; TODO: Use a better number?
+        furball.nbcolors = 15;
     // hair
     for(int i = 0; i < hairtypes_end; i++){
         furball.hairlength[i] = 1001;//default to long unkempt hair

--- a/commonTypes.h
+++ b/commonTypes.h
@@ -303,7 +303,7 @@ struct SS_Unit{
 
     int32_t squad_leader_id;
     uint32_t nbcolors;
-    uint32_t color[DFHack::Units::MAX_COLORS];
+    uint32_t color[15]; // Was using DFHack::Units::MAX_COLORS for no apparent reason; TODO: Use a better number?
 
     hairstyles hairstyle[hairtypes_end];
     uint32_t hairlength[hairtypes_end];


### PR DESCRIPTION
`DFHack::Units::MAX_COLORS` is being removed because it's not used (properly) anywhere, and is equivalent to `DFHack::COLOR_MAX` (AFAIK of its intent).

I've replaced the usage of it in Stonesense with the equivalent value of `15`, since it wasn't even being used as a color enum. The value is currently being used as however many elements of `unit.appearance.colors` we're willing to store in the `SS_Unit` struct. Note that these elements are used as indices to get `caste_raw` pattern data such as what color the unit's hair is at a given age. Stonesense only needs to know what color it is *right now*, so this is due for a rework.