### PR TITLE
Stonesense On-Screen Display hidden by default in config.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -423,7 +423,7 @@ static void * stonesense_thread(ALLEGRO_THREAD * main_thread, void * parms)
     ssState.Size.y = DEFAULT_SIZE;
     ssState.Size.z = DEFAULT_SIZE_Z;
     ssConfig.show_creature_names = true;
-    ssConfig.show_osd = true;
+    ssConfig.show_osd = false;
     ssConfig.show_designations = true;
     ssConfig.show_keybinds = false;
     ssConfig.show_intro = true;

--- a/resources/init.txt
+++ b/resources/init.txt
@@ -100,14 +100,14 @@ Options to control how names are displayed (if SHOW_CREATURE_NAMES is set)
 [NAMES_USE_SPECIES:YES]
 
 Enables or disables the entire on-screen-display overlay (Toggle with F2)
-[SHOW_OSD:YES]
+[SHOW_OSD:NO]
 
 Shows all creatures, for debugging. Living, dead, kidnapped, caged, EVERY single one.
 [ALLCREATURES:NO]
 
 Adds more logging information to what is written to stonesense.log. May be useful
 if trying having issues with sprite configuration tweaking.
-[VERBOSE_LOGGING:NO]
+[VERBOSE_LOGGING:YES]
 
 --Troubleshooting--
 


### PR DESCRIPTION
this might crash on Linux, but i cant check and it's probably an allegro issue.