### PR TITLE
Patchfix for the resize crash.

### DIFF
--- a/configs/init.txt
+++ b/configs/init.txt
@@ -131,7 +131,8 @@ and possibly quickly fill up yout hard-drive.
 
 Set the preferred renderer. Valid values are SOFTWARE, OPENGL, DIRECTX, and ANY. SOFTWARE has the highest
 compatibility, but is very slow.
-[RENDERER:ANY]
+On Windows, you should leave this on OPENGL for stability reasons.
+[RENDERER:OPENGL]
 
 --Colors--
 


### PR DESCRIPTION
Addresses https://github.com/DFHack/stonesense/issues/98,  https://github.com/DFHack/stonesense/issues/38, and https://github.com/DFHack/stonesense/issues/69