### PR TITLE
fix resize crash

### DIFF
--- a/WorldSegment.cpp
+++ b/WorldSegment.cpp
@@ -272,9 +272,23 @@ void WorldSegment::DrawAllTiles()
                 al_hold_bitmap_drawing(true);
             }
             switch(todraw[i].type) {
+            case Fog:
+                al_draw_tinted_scaled_bitmap(
+                    fog,
+                    todraw[i].tint,
+                    todraw[i].sx,
+                    todraw[i].sy,
+                    todraw[i].sw,
+                    todraw[i].sh,
+                    todraw[i].dx,
+                    todraw[i].dy,
+                    todraw[i].dw,
+                    todraw[i].dh,
+                    todraw[i].flags);
+                break;
             case TintedScaledBitmap:
                 al_draw_tinted_scaled_bitmap(
-                    (ALLEGRO_BITMAP*) todraw[i].drawobject,
+                    std::get<ALLEGRO_BITMAP*>(todraw[i].drawobject),
                     todraw[i].tint,
                     todraw[i].sx,
                     todraw[i].sy,
@@ -290,7 +304,7 @@ void WorldSegment::DrawAllTiles()
                 DrawCreatureText(
                     todraw[i].dx,
                     todraw[i].dy,
-                    (Stonesense_Unit*) todraw[i].drawobject );
+                    std::get<Stonesense_Unit*>(todraw[i].drawobject));
                 break;
             }
         }
@@ -325,8 +339,8 @@ void WorldSegment::AssembleAllTiles()
         //add the fog to the queue
         if(ssConfig.fogenable && fog) {
             draw_event d = {
-                TintedScaledBitmap,
-                fog,
+                Fog,
+                std::monostate{},
                 al_map_rgb(255,255,255),
                 0,
                 0,

--- a/WorldSegment.h
+++ b/WorldSegment.h
@@ -1,18 +1,23 @@
 #pragma once
 
+#include <variant>
 
 #include "common.h"
 
 #include "Tile.h"
 
+
 enum draw_event_type{
+    Fog,
     TintedScaledBitmap,
     CreatureText
 };
 
+struct Stonesense_Unit;
+
 struct draw_event{
     draw_event_type type;
-    void * drawobject;
+    std::variant<std::monostate,ALLEGRO_BITMAP*,Stonesense_Unit*> drawobject;
     ALLEGRO_COLOR tint;
     float sx;
     float sy;

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `stonesense`: fixed crash when maximizing or resizing the window
 
 ## Misc Improvements
 - `stonesense`: changed announcements to be right-aligned and limited to only show the most recent 10 announcements

--- a/main.cpp
+++ b/main.cpp
@@ -341,23 +341,14 @@ static void main_loop(ALLEGRO_DISPLAY * display, ALLEGRO_EVENT_QUEUE *queue, ALL
                 if (ssConfig.overlay_mode) {
                     break;
                 }
-                if(!al_acknowledge_resize(event.display.source)) {
+                timeToReloadSegment = true;
+                redraw = true;
+                ssState.ScreenH = event.display.height;
+                ssState.ScreenW = event.display.width;
+                if (!al_acknowledge_resize(event.display.source)) {
                     con.printerr("Failed to resize diplay");
                     return;
                 }
-                timeToReloadSegment = true;
-                redraw = true;
-#if 1
-                {
-                    //XXX the opengl drivers currently don't resize the backbuffer
-                    ALLEGRO_BITMAP *bb = al_get_backbuffer(al_get_current_display());
-                    int w = al_get_bitmap_width(bb);
-                    int h = al_get_bitmap_height(bb);
-                    ssState.ScreenH = h;
-                    ssState.ScreenW = w;
-                    PrintMessage("backbuffer w, h: %d, %d\n", w, h);
-                }
-#endif
                 break;
                 /* ALLEGRO_EVENT_KEY_DOWN - a keyboard key was pressed.
                 */


### PR DESCRIPTION
The draw event for fog was pushing a pointer to the global fog bitmap, which would be regenerated after a resize, thus changing it address, thus leaving the draw event pointing to a freed object. The regeneration of the fog takes place _after_ the draw event is pushed to the draw event list.

This was resolved by creating a Fog draw event that does not hold a pointer to the fog bitmap; instead the draw event processor will grab the _current_ global fog bitmap at the time it processes a Fog draw event.

Also replaced `void *` in `draw_event` with a `std::variant` and did some other cleanup around resize processing

Fixes: https://github.com/DFHack/stonesense/issues/98
Fixes: https://github.com/DFHack/stonesense/issues/38
Fixes: https://github.com/DFHack/stonesense/issues/69