### PR TITLE
Code quality update for Stonesense, pt. 3

### DIFF
--- a/ContentLoader.cpp
+++ b/ContentLoader.cpp
@@ -157,13 +157,7 @@ bool ContentLoader::Load()
 
                     size_t ent_id = currentity->id;
                     size_t pos_id = currentpos->id;
-                    if (ent_id >= position_Indices.size())
-                        position_Indices.resize(ent_id + 1, NULL);
-                    if (!position_Indices[ent_id])
-                        position_Indices[ent_id] = new vector<int32_t>; // EXPLICIT NEW
-                    if (pos_id >= position_Indices[ent_id]->size())
-                        position_Indices[ent_id]->resize(pos_id + 1, -1);
-                    position_Indices[ent_id]->at(pos_id) = found;
+                    position_Indices.add(ent_id, pos_id, found);
                 };
 
             for(size_t j = 0; j < currentity->positions.own.size(); j++) {

--- a/ContentLoader.cpp
+++ b/ContentLoader.cpp
@@ -36,7 +36,7 @@ using namespace df::enums;
 using std::vector;
 using std::string;
 
-ContentLoader * contentLoader;
+std::unique_ptr<ContentLoader> contentLoader;
 
 ContentLoader::ContentLoader(void) { }
 ContentLoader::~ContentLoader(void)

--- a/ContentLoader.cpp
+++ b/ContentLoader.cpp
@@ -160,7 +160,7 @@ bool ContentLoader::Load()
                     if (ent_id >= position_Indices.size())
                         position_Indices.resize(ent_id + 1, NULL);
                     if (!position_Indices[ent_id])
-                        position_Indices[ent_id] = new vector<int32_t>;
+                        position_Indices[ent_id] = new vector<int32_t>; // EXPLICIT NEW
                     if (pos_id >= position_Indices[ent_id]->size())
                         position_Indices[ent_id]->resize(pos_id + 1, -1);
                     position_Indices[ent_id]->at(pos_id) = found;
@@ -689,20 +689,7 @@ int loadConfigImgFile(std::filesystem::path filename, TiXmlElement* referrer)
 
 void ContentLoader::flushCreatureConfig()
 {
-    // make big enough to hold all creatures
     creatureConfigs.clear();
-    for ( size_t i = 0; i < style_indices.size();i++){
-        if(style_indices[i]){
-            for ( size_t j = 0; j < style_indices[i]->size();j++){
-                if(style_indices[i]->at(j)){
-                    style_indices[i]->at(j)->clear();
-                    delete style_indices[i]->at(j);
-                }
-            }
-            style_indices[i]->clear();
-            delete style_indices[i];
-        }
-    }
     style_indices.clear();
 }
 
@@ -729,21 +716,11 @@ void ContentLoader::gatherStyleIndices(df::world_raws * raws)
                 else LogError("Unknown hair type: %s", raws->creatures.all[creatureIndex]->caste[casteIndex]->tissue_styles[styleIndex]->token.c_str());
                 if(type != hairtypes_invalid)
                 {
-                    if(creatureIndex >= style_indices.size())
-                        style_indices.resize(creatureIndex+1, NULL);
-                    if(!style_indices.at(creatureIndex))
-                        style_indices.at(creatureIndex) = new vector<vector<int32_t>*>;
-                    vector<vector<int32_t>*>* creatureStyle = style_indices.at(creatureIndex);
-                    if(casteIndex >= creatureStyle->size())
-                        creatureStyle->resize(casteIndex+1, NULL);
-                    if(!creatureStyle->at(casteIndex))
-                        creatureStyle->at(casteIndex) = new vector<int32_t>;
-                    vector<int32_t>* casteStyle = creatureStyle->at(casteIndex);
-                    size_t typeIdx{ size_t(type) };
-                    if(typeIdx >= casteStyle->size())
-                        casteStyle->resize(typeIdx+1, 0);
-                    casteStyle->at(typeIdx) = sty->id;
-                    LogVerbose("%s:%s : %d:%s\n", raws->creatures.all[creatureIndex]->creature_id.c_str(),raws->creatures.all[creatureIndex]->caste[casteIndex]->caste_id.c_str(), sty->id, sty->token.c_str());
+                    style_indices.add(creatureIndex, casteIndex, type, sty->id);
+                    LogVerbose("%s:%s : %d:%s\n",
+                        raws->creatures.all[creatureIndex]->creature_id.c_str(),
+                        raws->creatures.all[creatureIndex]->caste[casteIndex]->caste_id.c_str(),
+                        sty->id, sty->token.c_str());
                 }
             }
         }

--- a/ContentLoader.h
+++ b/ContentLoader.h
@@ -61,7 +61,7 @@ public:
 
     class StyleIndices {
         using Key = std::tuple<int32_t, int32_t, int32_t>;
-        struct KeyHash
+        struct Hash
         {
             std::size_t operator()(const Key& k) const noexcept
             {
@@ -69,7 +69,7 @@ public:
             }
         };
 
-        std::unordered_map<Key, int32_t, KeyHash> style_indices;
+        std::unordered_map<Key, int32_t, Hash> style_indices;
 
     public:
         void clear()

--- a/ContentLoader.h
+++ b/ContentLoader.h
@@ -153,7 +153,7 @@ public:
     int obsidian = 0;
 };
 
-extern ContentLoader * contentLoader;
+extern std::unique_ptr<ContentLoader> contentLoader;
 
 extern const char* getDocument(TiXmlNode* element);
 std::filesystem::path getLocalFilename(std::filesystem::path filename, std::filesystem::path relativeto);

--- a/ContentLoader.h
+++ b/ContentLoader.h
@@ -59,8 +59,58 @@ public:
     FluidConfiguration lava[8];
     FluidConfiguration water[8];
 
-    //race.caste.hairtype.styletype
-    std::vector<std::vector<std::vector<int32_t>*>*> style_indices;
+    class StyleIndices {
+        //race.caste.hairtype.styletype
+        std::vector<std::vector<std::vector<int32_t>*>*> style_indices;
+    public:
+        void clear()
+        {
+            for (size_t i = 0; i < style_indices.size(); i++) {
+                if (style_indices[i]) {
+                    for (size_t j = 0; j < style_indices[i]->size(); j++) {
+                        if (style_indices[i]->at(j)) {
+                            style_indices[i]->at(j)->clear();
+                            delete style_indices[i]->at(j);// EXPLICIT DELETE
+                        }
+                    }
+                    style_indices[i]->clear();
+                    delete style_indices[i];// EXPLICIT DELETE
+                }
+            }
+            style_indices.clear();
+        }
+        void add(int creatureIndex, int casteIndex, int type, int id)
+        {
+            if (creatureIndex >= style_indices.size())
+                style_indices.resize(creatureIndex + 1, NULL);
+            if (!style_indices.at(creatureIndex))
+                style_indices.at(creatureIndex) = new std::vector<std::vector<int32_t>*>; // EXPLICIT NEW
+            std::vector<std::vector<int32_t>*>* creatureStyle = style_indices.at(creatureIndex);
+            if (casteIndex >= creatureStyle->size())
+                creatureStyle->resize(casteIndex + 1, NULL);
+            if (!creatureStyle->at(casteIndex))
+                creatureStyle->at(casteIndex) = new std::vector<int32_t>;  // EXPLICIT NEW
+            std::vector<int32_t>* casteStyle = creatureStyle->at(casteIndex);
+            size_t typeIdx{ size_t(type) };
+            if (typeIdx >= casteStyle->size())
+                casteStyle->resize(typeIdx + 1, 0);
+            casteStyle->at(typeIdx) = id;
+        }
+        int lookup(int race, int caste, int style_type)
+        {
+            if (size_t(race) < style_indices.size() && style_indices.at(race)) {
+                if (size_t(caste) < style_indices.at(race)->size() && style_indices.at(race)->at(caste)) {
+                    for (size_t j = 0; j < style_indices.at(race)->at(caste)->size(); j++) {
+                        if (style_type == style_indices.at(race)->at(caste)->at(j)) {
+                            return j;
+                        }
+                    }
+                }
+            }
+            return -1;
+        }
+    };
+    StyleIndices style_indices;
     std::vector<std::vector<int32_t>*> position_Indices;
 
     std::vector<std::string> professionStrings;

--- a/Creatures.cpp
+++ b/Creatures.cpp
@@ -547,7 +547,7 @@ namespace {
 
         std::vector<Units::NoblePosition> np;
         if (Units::getNoblePositions(&np, source)) {
-            furball.profession = contentLoader->position_Indices[np[0].entity->id]->at(np[0].position->id);
+            furball.profession = contentLoader->position_Indices.lookup(np[0].entity->id, np[0].position->id);
         }
 
 

--- a/Creatures.cpp
+++ b/Creatures.cpp
@@ -532,16 +532,12 @@ namespace {
             furball.hairlength[i] = 1001;//default to long unkempt hair
             furball.hairstyle[i] = CLEAN_SHAVEN;
         }
-        if (size_t(source->race) < contentLoader->style_indices.size() && contentLoader->style_indices.at(source->race)) {
-            if (size_t(source->caste) < contentLoader->style_indices.at(source->race)->size() && contentLoader->style_indices.at(source->race)->at(source->caste)) {
-                for (size_t i = 0; i < source->appearance.tissue_style_type.size(); i++) {
-                    for (size_t j = 0; j < contentLoader->style_indices.at(source->race)->at(source->caste)->size(); j++) {
-                        if (source->appearance.tissue_style_type[i] == contentLoader->style_indices.at(source->race)->at(source->caste)->at(j)) {
-                            furball.hairlength[j] = source->appearance.tissue_length[i];
-                            furball.hairstyle[j] = (hairstyles)source->appearance.tissue_style[i];
-                        }
-                    }
-                }
+        for (size_t i = 0; i < source->appearance.tissue_style_type.size(); i++) {
+            int j = contentLoader->style_indices.lookup(source->race, source->caste, source->appearance.tissue_style_type[i]);
+            if (j != -1)
+            {
+                furball.hairlength[j] = source->appearance.tissue_length[i];
+                furball.hairstyle[j] = (hairstyles)source->appearance.tissue_style[i];
             }
         }
 

--- a/SpriteMaps.cpp
+++ b/SpriteMaps.cpp
@@ -13,7 +13,7 @@ using namespace df::enums;
 c_sprite *  GetTerrainSpriteMap(int in, t_matglossPair material, vector<std::unique_ptr<TerrainConfiguration>>& configTable, uint16_t form)
 {
     // in case we need to return nothing
-    static c_sprite* defaultSprite = new c_sprite;
+    static c_sprite* defaultSprite = new c_sprite;  // EXPLICIT NEW
     defaultSprite->reset();
     defaultSprite->set_sheetindex(UNCONFIGURED_INDEX);
     defaultSprite->set_fileindex(INVALID_INDEX);

--- a/SpriteMaps.cpp
+++ b/SpriteMaps.cpp
@@ -13,11 +13,11 @@ using namespace df::enums;
 c_sprite *  GetTerrainSpriteMap(int in, t_matglossPair material, vector<std::unique_ptr<TerrainConfiguration>>& configTable, uint16_t form)
 {
     // in case we need to return nothing
-    static c_sprite* defaultSprite = new c_sprite;  // EXPLICIT NEW
-    defaultSprite->reset();
-    defaultSprite->set_sheetindex(UNCONFIGURED_INDEX);
-    defaultSprite->set_fileindex(INVALID_INDEX);
-    defaultSprite->set_needoutline(1);
+    static c_sprite defaultSprite{};
+    defaultSprite.reset();
+    defaultSprite.set_sheetindex(UNCONFIGURED_INDEX);
+    defaultSprite.set_fileindex(INVALID_INDEX);
+    defaultSprite.set_needoutline(1);
 
     int tempform;
     switch (form)
@@ -35,17 +35,17 @@ c_sprite *  GetTerrainSpriteMap(int in, t_matglossPair material, vector<std::uni
         tempform = FORM_LOG;
         break;
     default:
-        return defaultSprite;
+        return &defaultSprite;
     }
 
     // first check the input is sane
     if( in < 0 || in >= (int)configTable.size() ) {
-        return defaultSprite;
+        return &defaultSprite;
     }
     // find a matching terrainConfig
     TerrainConfiguration* terrain = configTable[in].get();
     if (terrain == nullptr) {
-        return defaultSprite;
+        return &defaultSprite;
     }
     // find mat config
 

--- a/SpriteObjects.cpp
+++ b/SpriteObjects.cpp
@@ -317,11 +317,11 @@ uint8_t getUnBorders(const char* framestring)
     return aframes;
 }
 
-c_sprite::c_sprite(void)
+c_sprite::c_sprite()
 {
     reset();
 }
-void c_sprite::reset(void)
+void c_sprite::reset()
 {
     fileindex = -1;
     sheetindex = 0;

--- a/SpriteObjects.h
+++ b/SpriteObjects.h
@@ -127,8 +127,8 @@ private:
     ALLEGRO_COLOR growthColor;
 public:
     void set_growthColor(ALLEGRO_COLOR color);
-    c_sprite(void);
-    ~c_sprite(void);
+    c_sprite();
+    ~c_sprite();
     //void draw_screen(int x, int y);
     inline void assemble_world(int x, int y, int z, Tile * b, bool chop=false)
     {

--- a/WorldSegment.h
+++ b/WorldSegment.h
@@ -33,7 +33,7 @@ struct draw_event{
 class WorldSegment
 {
 private:
-    Tile* tiles;
+    std::vector<Tile> tiles;
     std::vector<draw_event> todraw;
 
     std::vector<std::unique_ptr<Stonesense_Unit>> units;
@@ -49,12 +49,12 @@ public:
         segState.Position.z = segState.Position.z - segState.Size.z + 1;
 
         uint32_t newNumTiles = inState.Size.x * inState.Size.y * inState.Size.z;
-        tiles = new Tile[newNumTiles]();  // EXPLICIT NEW
+        tiles.clear();
+        tiles.insert(tiles.end(), newNumTiles, {});
     }
 
     ~WorldSegment() {
-        delete[] tiles;   // EXPLICIT DELETE
-        tiles = NULL;
+        tiles.clear();
         ClearBuildings();
         ClearUnits();
     }
@@ -68,14 +68,13 @@ public:
         uint32_t newNumTiles = inState.Size.x * inState.Size.y * inState.Size.z;
         //if this is a hard reset, or if the size doesn't match what is needed, get a new segment
         if(hard || newNumTiles != getNumTiles()) {
-            delete[] tiles; // EXPLICIT DELETE
-            tiles = new Tile[newNumTiles]();  // EXPLICIT NEW
+            tiles.clear();
+            tiles.insert(tiles.end(), newNumTiles, {});
         }
         else {
             // Otherwise, reset all existing tiles to their initial state
-            for(uint32_t i = 0; i < getNumTiles(); i++) {
-                tiles[i].Reset();
-            }
+            for (auto& t : tiles)
+                t.Reset();
         }
 
         segState = inState;

--- a/WorldSegment.h
+++ b/WorldSegment.h
@@ -49,11 +49,11 @@ public:
         segState.Position.z = segState.Position.z - segState.Size.z + 1;
 
         uint32_t newNumTiles = inState.Size.x * inState.Size.y * inState.Size.z;
-        tiles = new Tile[newNumTiles]();
+        tiles = new Tile[newNumTiles]();  // EXPLICIT NEW
     }
 
     ~WorldSegment() {
-        delete[] tiles;
+        delete[] tiles;   // EXPLICIT DELETE
         tiles = NULL;
         ClearBuildings();
         ClearUnits();
@@ -68,8 +68,8 @@ public:
         uint32_t newNumTiles = inState.Size.x * inState.Size.y * inState.Size.z;
         //if this is a hard reset, or if the size doesn't match what is needed, get a new segment
         if(hard || newNumTiles != getNumTiles()) {
-            delete[] tiles;
-            tiles = new Tile[newNumTiles]();
+            delete[] tiles; // EXPLICIT DELETE
+            tiles = new Tile[newNumTiles]();  // EXPLICIT NEW
         }
         else {
             // Otherwise, reset all existing tiles to their initial state

--- a/commonTypes.h
+++ b/commonTypes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <unordered_map>
 
 #include "common.h"
 #include "SpriteColors.h"
@@ -339,3 +340,33 @@ struct Stonesense_Building
     int32_t custom_type;
     df::building* origin;
 };
+
+template <typename Key, typename Val, typename Hash = std::hash<Key>>
+class SparseArray {
+
+    std::unordered_map< Key, Val, Hash> map;
+
+public:
+    void clear()
+    {
+        map.clear();
+    }
+    void add(Key&& k, Val& v)
+    {
+        auto it = map.find(k);
+        if (it != map.end())
+        {
+            it->second = v;
+        }
+        else
+        {
+            map.emplace(k, v);
+        }
+    }
+    std::optional<Val> lookup(Key&& k)
+    {
+        auto it = map.find(k);
+        return it != map.end() ? std::optional{ it->second } : std::nullopt;
+    }
+};
+

--- a/main.cpp
+++ b/main.cpp
@@ -435,7 +435,7 @@ static void * stonesense_thread(ALLEGRO_THREAD * main_thread, void * parms)
     ssConfig.threading_enable = 1;
     ssConfig.fog_of_war = 1;
     ssConfig.occlusion = 1;
-    contentLoader = new ContentLoader();
+    contentLoader = new ContentLoader();  // EXPLICIT NEW
     ssConfig.zoom = 0;
     ssConfig.scale = 1.0f;
     ssConfig.useDfColors = false;
@@ -579,7 +579,7 @@ static void * stonesense_thread(ALLEGRO_THREAD * main_thread, void * parms)
     map_segment.unlock();
     al_destroy_bitmap(IMGIcon);
     IMGIcon = 0;
-    delete contentLoader;
+    delete contentLoader; // EXPLICIT DELETE
     contentLoader = 0;
     out.print("Stonesense shutdown.\n");
     stonesense_started = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -18,13 +18,12 @@
 #include "ContentLoader.h"
 #include "OcclusionTest.h"
 
-using namespace std;
 using namespace DFHack;
 using namespace df::enums;
 
-#define WIDTH        640
-#define HEIGHT       480
-#define SIZE_LOG     50
+static constexpr auto WIDTH = 640;
+static constexpr auto HEIGHT = 480;
+static constexpr auto SIZE_LOG = 50;
 
 //set the plugin name/dfhack version
 DFHACK_PLUGIN("stonesense");
@@ -47,7 +46,7 @@ char currentAnimationFrame;
 uint32_t currentFrameLong;
 bool animationFrameShown;
 
-vector<t_matgloss> v_stonetypes;
+std::vector<t_matgloss> v_stonetypes;
 
 ALLEGRO_FONT * font;
 

--- a/main.cpp
+++ b/main.cpp
@@ -435,7 +435,7 @@ static void * stonesense_thread(ALLEGRO_THREAD * main_thread, void * parms)
     ssConfig.threading_enable = 1;
     ssConfig.fog_of_war = 1;
     ssConfig.occlusion = 1;
-    contentLoader = new ContentLoader();  // EXPLICIT NEW
+    contentLoader = std::make_unique<ContentLoader>();
     ssConfig.zoom = 0;
     ssConfig.scale = 1.0f;
     ssConfig.useDfColors = false;
@@ -579,8 +579,7 @@ static void * stonesense_thread(ALLEGRO_THREAD * main_thread, void * parms)
     map_segment.unlock();
     al_destroy_bitmap(IMGIcon);
     IMGIcon = 0;
-    delete contentLoader; // EXPLICIT DELETE
-    contentLoader = 0;
+    contentLoader.reset();
     out.print("Stonesense shutdown.\n");
     stonesense_started = 0;
     return NULL;


### PR DESCRIPTION
The main change here is to switch two data structures from nested sparsely populated vectors to hashmaps, while at the same time introducing a clearer API to these structures that makes code using them less hard to understand.

The remaining uses of explicit `new`/explicit `delete` have been replaced with idioms that allow for the STL to manage lifetime.

Some old-fashioned C-style syntax has been updated to modern C++ standards.

