### PR TITLE
Add Gap-Removing Features

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -5,6 +6,7 @@
 #include "common.h"
 #include "commonTypes.h"
 #include "Config.h"
+#include "GameConfiguration.h"
 #include "GameState.h"
 #include "StonesenseState.h"
 
@@ -798,6 +800,14 @@ namespace {
             config.software = (result == "SOFTWARE");
             config.directX = (result == "DIRECTX");
         }
+        if (line.find("[EXTRUDE_TILES") != string::npos) {
+            string result = parseStrFromLine("EXTRUDE_TILES", line);
+            config.extrude_tiles = (result == "YES");
+        }
+        if (line.find("[PIXELPERFECT_ZOOM") != string::npos) {
+            string result = parseStrFromLine("PIXELPERFECT_ZOOM", line);
+            config.pixelperfect_zoom = (result == "YES");
+        }
         if (line.find("[NIGHT") != string::npos) {
             string result = parseStrFromLine("NIGHT", line);
             config.dayNightCycle = (result == "YES");
@@ -841,4 +851,16 @@ bool loadConfigFile()
 
 
     return true;
+}
+
+// Set the proper scale based on the current zoom level
+void GameConfiguration::recalculateScale() {
+    if (this->config.pixelperfect_zoom) {
+        if (zoom > 0)
+            scale = zoom;
+        else
+            scale = std::pow(0.5, -zoom + 1);
+    } else {
+        scale = std::pow(SCALEZOOMFACTOR, zoom);
+    }
 }

--- a/Config.h
+++ b/Config.h
@@ -68,6 +68,8 @@ public:
     bool dayNightCycle = false;
     int imageCacheSize = 4096;
     bool fog_of_war = true;
+    bool extrude_tiles = true;
+    bool pixelperfect_zoom = false;
 };
 
 struct action_name_mapper {

--- a/GUI.cpp
+++ b/GUI.cpp
@@ -1195,6 +1195,13 @@ void saveMegashot(bool tall)
     ssConfig.config.fogenable = false;
     ssConfig.track_screen_center = false;
 
+    // Disable due to minor visual artifacts
+    ssConfig.config.extrude_tiles = false;
+    // Ensure the scale is exactly 1
+    ssConfig.config.pixelperfect_zoom = true;
+    ssConfig.zoom = 1;
+    ssConfig.recalculateScale();
+
     //make the image
     ssState.ScreenW = ((ssState.RegionDim.x + ssState.RegionDim.y) * TILEWIDTH / 2)*ssConfig.scale;
     if(tall) {

--- a/GameConfiguration.h
+++ b/GameConfiguration.h
@@ -61,4 +61,6 @@ struct GameConfiguration {
 
     int zoom = 0;
     float scale = 1.0f;
+
+    void recalculateScale();
 };

--- a/MapLoading.cpp
+++ b/MapLoading.cpp
@@ -962,7 +962,7 @@ void read_segment( void *arg)
                 stonesenseState.ssConfig.config.follow_DFcursor = true;
             }
             stonesenseState.ssConfig.zoom = (df::global::gps->viewport_zoom_factor - 64) / 16;
-            stonesenseState.ssConfig.scale = std::pow(SCALEZOOMFACTOR, stonesenseState.ssConfig.zoom);
+            stonesenseState.ssConfig.recalculateScale();
         }
         segment = stonesenseState.map_segment.getRead();
         readMapSegment(segment, ssState);

--- a/UserInput.cpp
+++ b/UserInput.cpp
@@ -459,14 +459,14 @@ void action_incrzoom(uint32_t keymod)
 {
     auto& ssConfig = stonesenseState.ssConfig;
     ssConfig.zoom++;
-    ssConfig.scale = std::pow(SCALEZOOMFACTOR, ssConfig.zoom);
+    ssConfig.recalculateScale();
 }
 
 void action_decrzoom(uint32_t keymod)
 {
     auto& ssConfig = stonesenseState.ssConfig;
     ssConfig.zoom--;
-    ssConfig.scale = std::pow(SCALEZOOMFACTOR, ssConfig.zoom);
+    ssConfig.recalculateScale();
 }
 
 void action_screenshot(uint32_t keymod)

--- a/WorldSegment.cpp
+++ b/WorldSegment.cpp
@@ -267,31 +267,34 @@ void WorldSegment::DrawAllTiles()
 
     if(todraw.size()>0) {
         al_hold_bitmap_drawing(true);
+
+        int extrude = ssConfig.config.extrude_tiles;
+        auto DrawBitmap = [&](ALLEGRO_BITMAP* b, draw_event& todraw) {
+            al_draw_tinted_scaled_bitmap(
+                b,
+                todraw.tint,
+                todraw.sx,
+                todraw.sy,
+                todraw.sw,
+                todraw.sh,
+                todraw.dx - extrude,
+                todraw.dy - extrude,
+                todraw.dw + (extrude*2),
+                todraw.dh + (extrude*2),
+                todraw.flags);
+            };
+
         for(size_t i=0; i<todraw.size(); i++) {
-            auto DrawBitmap = [&](ALLEGRO_BITMAP* b) {
-                al_draw_tinted_scaled_bitmap(
-                    b,
-                    todraw[i].tint,
-                    todraw[i].sx,
-                    todraw[i].sy,
-                    todraw[i].sw,
-                    todraw[i].sh,
-                    todraw[i].dx,
-                    todraw[i].dy,
-                    todraw[i].dw,
-                    todraw[i].dh,
-                    todraw[i].flags);
-                };
             if(i%ssConfig.config.bitmapHolds==0) {
                 al_hold_bitmap_drawing(false);
                 al_hold_bitmap_drawing(true);
             }
             switch(todraw[i].type) {
             case Fog:
-                DrawBitmap(fog);
+                DrawBitmap(fog, todraw[i]);
                 break;
             case TintedScaledBitmap:
-                DrawBitmap(std::get<ALLEGRO_BITMAP*>(todraw[i].drawobject));
+                DrawBitmap(std::get<ALLEGRO_BITMAP*>(todraw[i].drawobject), todraw[i]);
                 break;
             case CreatureText:
                 DrawCreatureText(

--- a/configs/init.txt
+++ b/configs/init.txt
@@ -139,6 +139,15 @@ Set the preferred renderer. Valid values are SOFTWARE, OPENGL, DIRECTX, and ANY.
 compatibility, but is very slow.
 [RENDERER:ANY]
 
+If this is set to YES, Stonesense will extrude all visible sprites by 1 pixel in each direction
+to suppress visible gaps. This setting is uneeded when PIXELPERFECT_ZOOM is enabled.
+[EXTRUDE_TILES:YES]
+
+If this is set to YES, Stonesense will zoom on whole pixel scale instead of subpixel.
+This will prevent visible gaps between tiles, but makes zoom levels far less granular,
+and may provide unusual zoom when following the DwarfFortress camera.
+[PIXELPERFECT_ZOOM:NO]
+
 --Colors--
 
 Stonesense can use the colors from DF for various purposes.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,8 @@ Template for new versions:
 # Future
 
 ## New Features
+ - `stonesense`: added option `EXTEND_TILES` to slightly expand sprite to avoid gaps (on by default)
+ - `stonesense`: added option `PIXELPERFECT_ZOOM` to change the zoom scale to avoid gaps (off by default)
 
 ## Fixes
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,8 +38,8 @@ Template for new versions:
 # Future
 
 ## New Features
- - `stonesense`: added option `EXTEND_TILES` to slightly expand sprite to avoid gaps (on by default)
- - `stonesense`: added option `PIXELPERFECT_ZOOM` to change the zoom scale to avoid gaps (off by default)
+- `stonesense`: added option ``EXTEND_TILES`` to slightly expand sprite to avoid gaps (on by default)
+- `stonesense`: added option ``PIXELPERFECT_ZOOM`` to change the zoom scale to avoid gaps (off by default)
 
 ## Fixes
 


### PR DESCRIPTION
Due to subpixel scaling, gaps could appear between tiles when zoomed in. This adds two new features which prevent these gaps from appearing.

`EXTRUDE_TILES` (on by default) expands every sprite by 1px in each direction, preventing gaps with minimal visual difference.

`PIXELPERFECT_ZOOM` (off by default) changes the scaling algorithm for zoom to be pixel perfect, losing some granularity in the process. This zoom algorithm does not work nicely with following DFs native zoom, so it is off by default.

Before:
![image](https://github.com/user-attachments/assets/d4180087-bd6c-44b2-beb8-9c26e6f86d4b)
After:
![image](https://github.com/user-attachments/assets/bf4466eb-aef1-4f3b-a1aa-fd2ce2bbdca9)
