### PR TITLE
Fix stale window size information

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `stonesense`: screen dimensions are now properly set when overriden by a window manager
 
 ## Misc Improvements
 

--- a/main.cpp
+++ b/main.cpp
@@ -408,6 +408,13 @@ static void* stonesense_thread(ALLEGRO_THREAD* main_thread, void* parms)
         stonesense_started = 0;
         return NULL;
     }
+
+    // Overwrite our screen size with the actual size.
+    // Window managers may overwrite our specified size without emiting
+    // a resize event for us.
+    stonesenseState.ssState.ScreenW = al_get_display_width(display);
+    stonesenseState.ssState.ScreenH = al_get_display_height(display);
+
     if(!al_is_keyboard_installed()) {
         if (!al_install_keyboard()) {
             out.printerr("Stonesense: al_install_keyboard failed\n");


### PR DESCRIPTION
Fixes stale window size information caused by the initial size being overwritten by a window manager. A resize event does not appear to be emitted, meaning it needs to be checked for directly.

Fixes #139 