### PR TITLE
Fix debug timers not displaying milliseconds

### DIFF
--- a/GUI.cpp
+++ b/GUI.cpp
@@ -863,6 +863,10 @@ void DoSpriteIndexOverlay()
     paintboard();
 }
 
+float clockToMs(float clockTicks) {
+    return clockTicks / (CLOCKS_PER_SEC/1000);
+}
+
 void paintboard()
 {
     DFHack::CoreSuspender suspend;
@@ -939,12 +943,12 @@ void paintboard()
 
         if(ssConfig.config.debug_mode) {
             auto& contentLoader = stonesenseState.contentLoader;
-            draw_textf_border(font, uiColor(1), 10, 3*fontHeight, 0, "Map Read Time: %.2fms", float(stonesenseState.stoneSenseTimers.read_time));
-            draw_textf_border(font, uiColor(1), 10, 4*fontHeight, 0, "Map Beautification Time: %.2fms", float(stonesenseState.stoneSenseTimers.beautify_time));
-            draw_textf_border(font, uiColor(1), 10, 5*fontHeight, 0, "Tile Sprite Assembly Time: %.2fms", float(stonesenseState.stoneSenseTimers.assembly_time));
-            draw_textf_border(font, uiColor(1), 10, 6*fontHeight, 0, "DF Renderer Overlay Time: %.2fms", float(stonesenseState.stoneSenseTimers.overlay_time));
-            draw_textf_border(font, uiColor(1), 10, 2*fontHeight, 0, "FPS: %.2f", float(1000.0/stonesenseState.stoneSenseTimers.frame_total));
-            draw_textf_border(font, uiColor(1), 10, 7*fontHeight, 0, "Draw: %.2fms", float(stonesenseState.stoneSenseTimers.draw_time));
+            draw_textf_border(font, uiColor(1), 10, 3*fontHeight, 0, "Map Read Time: %.2fms", clockToMs(stonesenseState.stoneSenseTimers.read_time));
+            draw_textf_border(font, uiColor(1), 10, 4*fontHeight, 0, "Map Beautification Time: %.2fms", clockToMs(stonesenseState.stoneSenseTimers.beautify_time));
+            draw_textf_border(font, uiColor(1), 10, 5*fontHeight, 0, "Tile Sprite Assembly Time: %.2fms", clockToMs(stonesenseState.stoneSenseTimers.assembly_time));
+            draw_textf_border(font, uiColor(1), 10, 6*fontHeight, 0, "DF Renderer Overlay Time: %.2fms", clockToMs(stonesenseState.stoneSenseTimers.overlay_time));
+            draw_textf_border(font, uiColor(1), 10, 2*fontHeight, 0, "FPS: %.2f", 1000.0/clockToMs(stonesenseState.stoneSenseTimers.frame_total));
+            draw_textf_border(font, uiColor(1), 10, 7*fontHeight, 0, "Draw: %.2fms", clockToMs(stonesenseState.stoneSenseTimers.draw_time));
             draw_textf_border(font, uiColor(1), 10, 9*fontHeight, 0, "%i/%i/%i, %i:%i", contentLoader->currentDay+1, contentLoader->currentMonth+1, contentLoader->currentYear, contentLoader->currentHour, (contentLoader->currentTickRel*60)/50);
 
             drawDebugInfo(segment);

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -46,6 +46,7 @@ Template for new versions:
 - `stonesense`: fixed announcement text rendering off-screen with larger font sizes
 - `stonesense`: screen dimensions are now properly set when overriden by a window manager
 - `stonesense`: fixed glass cabinets and bookcases being misaligned by 1 pixel
+- `stonesense`: fixed debug performance timers to show milliseconds as intended
 
 ## Misc Improvements
 - `stonesense`: improved the way altars look


### PR DESCRIPTION
The performance timers all counted in allegro clock cycles, which did not line up with the unit being displayed. This converts the timing into milliseconds before displaying the timings.