### PR TITLE
Remove uneccessary fog bitmap

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,6 +49,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `stonesense`: improved the way altars look
+- `stonesense`: fog no longer unnecessarily renders to a separate bitmap
 
 ## Removed
 


### PR DESCRIPTION
The fog bitmap was only being used to store the fog color and nothing else. This replaces the fog bitmap with a call to `al_draw_filled_rectangle`.

Visuals should not change at all, and I had not noticed a notable performance difference when using an accelerated backend.