### PR TITLE
Disable mipmapping with image_cache

### DIFF
--- a/configs/init.txt
+++ b/configs/init.txt
@@ -123,7 +123,8 @@ performance gains.
 [BITMAP_HOLDS:4096]
 
 Stonesense will try to merge all loaded sprites into a single texture, for performance reasons.
-if your videocard has low memory, you may want to disable this.
+if your videocard has low memory, you may want to disable this. Enabling this feature
+will disable mipmapping to prevent sprites from going transparent when zooming out.
 [CACHE_IMAGES:NO]
 
 This sets the preferred size of the internal image cache. If your videocard does not support it,

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -48,6 +48,7 @@ Template for new versions:
 - `stonesense`: fixed glass cabinets and bookcases being misaligned by 1 pixel
 - `stonesense`: vampires no longer show their true name when they shouldn't.
 - `stonesense`: fixed debug performance timers to show milliseconds as intended
+- `stonesense`: ``CACHE_IMAGES`` now disables mipmapping, stopping sprites from going transparent
 
 
 ## Misc Improvements

--- a/main.cpp
+++ b/main.cpp
@@ -399,7 +399,12 @@ static void* stonesense_thread(ALLEGRO_THREAD* main_thread, void* parms)
     if(ssConfig.config.software) {
         al_set_new_bitmap_flags(ALLEGRO_MEMORY_BITMAP|_ALLEGRO_ALPHA_TEST|ALLEGRO_MIN_LINEAR|ALLEGRO_MIPMAP);
     } else {
-        al_set_new_bitmap_flags(ALLEGRO_MIN_LINEAR|ALLEGRO_MIPMAP);
+        // FIXME: When we have ability to set a maximum mipmap lod,
+        // do so when cache_images is enabled to prevent sprites going transparent.
+        // Until then, disable mipmapping when using an image cache.
+        al_set_new_bitmap_flags(
+                ALLEGRO_MIN_LINEAR
+                |(ssConfig.config.cache_images ? 0 : ALLEGRO_MIPMAP));
     }
 
     display = al_create_display(stonesenseState.ssState.ScreenW, stonesenseState.ssState.ScreenH);


### PR DESCRIPTION
This prevents sprites from going transparent when zooming out.

This is a temporary solution until our renderer supports setting a max mipmap LOD, in which case mipmapping may remain enabled. Allegro does not support this currently, and would require modification or an extension to implement properly.