### PR TITLE
Fix some wall borders not being shown

### DIFF
--- a/Tile.cpp
+++ b/Tile.cpp
@@ -13,6 +13,7 @@
 #include "df/building_type.h"
 #include "df/plant_growth.h"
 #include "df/plant_growth_print.h"
+#include "df/tiletype.h"
 #include "df/world.h"
 
 ALLEGRO_BITMAP *sprite_miasma = 0;
@@ -721,18 +722,18 @@ bool hasBuildingOfIndex(Tile* b, Stonesense_Building* index)
     return b->building.info == index;
 }
 
-bool wallShouldNotHaveBorders( int in )
+bool wallShouldNotHaveBorders( df::tiletype in )
 {
     switch( in ) {
-    case 65: //stone fortification
-    case 436: //minstone fortification
-    case 326: //lavastone fortification
-    case 327: //featstone fortification
-    case 494: //constructed fortification
+    case df::tiletype::StoneFortification:
+    case df::tiletype::MineralFortification:
+    case df::tiletype::LavaFortification:
+    case df::tiletype::FeatureFortification:
+    case df::tiletype::ConstructedFortification:
         return true;
-        break;
+    default:
+        return false;
     };
-    return false;
 }
 
 bool containsDesignations( df::tile_designation des, df::tile_occupancy occ )

--- a/Tile.h
+++ b/Tile.h
@@ -134,7 +134,7 @@ bool hasWall(Tile* b);
 bool hasBuildingOfID(Tile* b, int ID);
 bool hasBuildingIdentity(Tile* b, Stonesense_Building* index, df::tile_building_occ buildingOcc);
 bool hasBuildingOfIndex(Tile* b, Stonesense_Building* index);
-bool wallShouldNotHaveBorders( int in );
+bool wallShouldNotHaveBorders( df::tiletype in );
 bool containsDesignations( df::tile_designation, df::tile_occupancy );
 
 inline bool IDisWall(int in)

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,7 +49,7 @@ Template for new versions:
 - `stonesense`: vampires no longer show their true name when they shouldn't.
 - `stonesense`: fixed debug performance timers to show milliseconds as intended
 - `stonesense`: ``CACHE_IMAGES`` now disables mipmapping, stopping sprites from going transparent
-
+- `stonesense`: fixed issue where depth borders wouldn't be rendered for some walls
 
 ## Misc Improvements
 - `stonesense`: improved the way altars look


### PR DESCRIPTION
The code was checking for hardcoded tiletype values instead of using the enum. As the values have shifted over time, some standard walls were being incorrectly treated as fortifications. This changes the function to refer to the enum values, ensuring they remain up to date.

Before:
![image](https://github.com/user-attachments/assets/60242541-bdaa-43d6-be6a-72f3693971c1)

After:
![image](https://github.com/user-attachments/assets/9ca4290b-f97e-4ba6-a4d4-fd493fc40fc8)

