### PR TITLE
Update sprite culling to account for offset

### DIFF
--- a/SpriteObjects.cpp
+++ b/SpriteObjects.cpp
@@ -1003,15 +1003,15 @@ void c_sprite::assemble_world_offset(int x, int y, int z, int plateoffset, Tile 
         pointToScreen((int*)&drawx, (int*)&drawy, drawz);
         drawx -= (TILEWIDTH>>1)*ssConfig.scale;
 
-        if(((drawx + spritewidth*ssConfig.scale) < 0) || (drawx > ssState.ScreenW) || ((drawy + spriteheight*ssConfig.scale) < 0) || (drawy > ssState.ScreenH)) {
+        if((drawx + (spritewidth+offset_x)*ssConfig.scale < 0)
+            || (drawx + offset_x*ssConfig.scale > ssState.ScreenW)
+            || (drawy + (spriteheight + offset_y)*ssConfig.scale < 0)
+            || (drawy + (offset_y - WALLHEIGHT)*ssConfig.scale > ssState.ScreenH)) {
             return;
         }
 
         int sheetx, sheety;
-        if(platelayout == TILEPLATE) {
-            sheetx = ((sheetindex+plateoffset+spriteoffset) % SHEET_OBJECTSWIDE) * spritewidth;
-            sheety = ((sheetindex+plateoffset+spriteoffset) / SHEET_OBJECTSWIDE) * spriteheight;
-        } else if(platelayout == RAMPBOTTOMPLATE) {
+        if(platelayout == RAMPBOTTOMPLATE) {
             sheetx = SPRITEWIDTH * b->rampindex;
             sheety = ((TILETOPHEIGHT + FLOORHEIGHT + SPRITEHEIGHT) * (sheetindex+plateoffset+spriteoffset))+(TILETOPHEIGHT + FLOORHEIGHT);
         } else if(platelayout == RAMPTOPPLATE) {
@@ -1021,9 +1021,10 @@ void c_sprite::assemble_world_offset(int x, int y, int z, int plateoffset, Tile 
             sheetx = ((sheetindex+plateoffset+spriteoffset) % SHEET_OBJECTSWIDE) * spritewidth;
             sheety = ((sheetindex+plateoffset+spriteoffset) / SHEET_OBJECTSWIDE) * spriteheight;
         }
+
         ALLEGRO_COLOR shade_color = shadeAdventureMode(get_color(b), b->fog_of_war, b->designation.bits.outside);
         if(chop && ( halftile == HALFPLATECHOP)) {
-            if(shade_color.a > 0.001f)
+            if(shade_color.a > 0.001f) {
                 b->AssembleSprite(
                     (fileindex >= 0) ? getImgFile(fileindex) : defaultsheet,
                     premultiply(shade_color),
@@ -1037,7 +1038,6 @@ void c_sprite::assemble_world_offset(int x, int y, int z, int plateoffset, Tile 
                     (spriteheight-WALL_CUTOFF_HEIGHT)*ssConfig.scale,
                     0);
 
-            if(shade_color.a > 0.001f) {
                 b->AssembleSprite(
                     stonesenseState.IMGObjectSheet,
                     al_map_rgb(255,255,255),
@@ -1052,34 +1052,19 @@ void c_sprite::assemble_world_offset(int x, int y, int z, int plateoffset, Tile 
             }
         } else if ((chop && (halftile == HALFPLATEYES)) || (!chop && (halftile == HALFPLATENO)) || (!chop && (halftile == HALFPLATECHOP)) || (halftile == HALFPLATEBOTH)) {
             if((isoutline == OUTLINENONE) || ((isoutline == OUTLINERIGHT) && (b->depthBorderNorth)) || ((isoutline == OUTLINELEFT) && (b->depthBorderWest)) || ((isoutline == OUTLINEBOTTOM) && (b->depthBorderDown))) {
-                if(fileindex < 0) {
-                    if(shade_color.a > 0.001f)
-                        b->AssembleSprite(
-                            defaultsheet, premultiply(shade_color),
-                            sheetx * spritescale,
-                            sheety * spritescale,
-                            spritewidth * spritescale,
-                            spriteheight * spritescale,
-                            drawx + (offset_x + offset_user_x)*ssConfig.scale,
-                            drawy + (offset_user_y + (offset_y - WALLHEIGHT))*ssConfig.scale,
-                            spritewidth*ssConfig.scale,
-                            spriteheight*ssConfig.scale,
-                            0);
-                } else {
-
-                    if(shade_color.a > 0.001f)
-                        b->AssembleSprite(
-                            getImgFile(fileindex),
-                            premultiply(shade_color),
-                            sheetx * spritescale,
-                            sheety * spritescale,
-                            spritewidth * spritescale,
-                            spriteheight * spritescale,
-                            drawx + (offset_x + offset_user_x)*ssConfig.scale,
-                            drawy + (offset_user_y + (offset_y - WALLHEIGHT))*ssConfig.scale,
-                            spritewidth*ssConfig.scale,
-                            spriteheight*ssConfig.scale,
-                            0);
+                if(shade_color.a > 0.001f) {
+                    b->AssembleSprite(
+                        fileindex < 0 ? defaultsheet : getImgFile(fileindex),
+                        premultiply(shade_color),
+                        sheetx * spritescale,
+                        sheety * spritescale,
+                        spritewidth * spritescale,
+                        spriteheight * spritescale,
+                        drawx + (offset_x + offset_user_x)*ssConfig.scale,
+                        drawy + (offset_user_y + (offset_y - WALLHEIGHT))*ssConfig.scale,
+                        spritewidth*ssConfig.scale,
+                        spriteheight*ssConfig.scale,
+                        0);
                 }
             }
             if(needoutline) {

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -50,6 +50,7 @@ Template for new versions:
 - `stonesense`: fixed debug performance timers to show milliseconds as intended
 - `stonesense`: ``CACHE_IMAGES`` now disables mipmapping, stopping sprites from going transparent
 - `stonesense`: fixed issue where depth borders wouldn't be rendered for some walls
+- `stonesense`: fixed issue where tiles near the bottom edge would be culled
 
 ## Misc Improvements
 - `stonesense`: improved the way altars look


### PR DESCRIPTION
Sprites were being culled for being off-screen because the check did not account for the y offsets that could occur. This updates the check to properly account for x and y offsets.

Fixes #171 