### PR TITLE
Tint the designations based on type, similar to DF

### DIFF
--- a/SpriteObjects.cpp
+++ b/SpriteObjects.cpp
@@ -1023,6 +1023,11 @@ void c_sprite::assemble_world_offset(int x, int y, int z, int plateoffset, Tile 
         }
 
         ALLEGRO_COLOR shade_color = shadeAdventureMode(get_color(b), b->fog_of_war, b->designation.bits.outside);
+        if (ssConfig.show_designations) {
+            if (b->occ.bits.dig_auto && containsDesignations(b->designation, b->occ)) { shade_color = al_map_rgba(0, 255, 127, 127); }
+            if (b->occ.bits.dig_marked && containsDesignations(b->designation, b->occ)) { shade_color = al_map_rgba(0, 127, 255, 127); }
+            if (b->occ.bits.dig_marked && b->occ.bits.dig_auto && containsDesignations(b->designation, b->occ)) { shade_color = partialBlend(shade_color, al_map_rgba(0, 255, 127, 127), 25); }
+        }
         if(chop && ( halftile == HALFPLATECHOP)) {
             if(shade_color.a > 0.001f) {
                 b->AssembleSprite(

--- a/SpriteObjects.cpp
+++ b/SpriteObjects.cpp
@@ -1023,10 +1023,14 @@ void c_sprite::assemble_world_offset(int x, int y, int z, int plateoffset, Tile 
         }
 
         ALLEGRO_COLOR shade_color = shadeAdventureMode(get_color(b), b->fog_of_war, b->designation.bits.outside);
-        if (ssConfig.show_designations) {
-            if (b->occ.bits.dig_auto && containsDesignations(b->designation, b->occ)) { shade_color = al_map_rgba(0, 255, 127, 127); }
-            if (b->occ.bits.dig_marked && containsDesignations(b->designation, b->occ)) { shade_color = al_map_rgba(0, 127, 255, 127); }
-            if (b->occ.bits.dig_marked && b->occ.bits.dig_auto && containsDesignations(b->designation, b->occ)) { shade_color = partialBlend(shade_color, al_map_rgba(0, 255, 127, 127), 25); }
+        if (ssConfig.show_designations && containsDesignations(b->designation, b->occ)) {
+            if (b->occ.bits.dig_auto) { shade_color = al_map_rgba(0, 255, 127, 127); }
+            if (b->occ.bits.dig_marked) {
+                shade_color = al_map_rgba(0, 127, 255, 127);
+                if (b->occ.bits.dig_auto) {
+                    shade_color = partialBlend(shade_color, al_map_rgba(0, 255, 127, 127), 25);
+                }
+            }
         }
         if(chop && ( halftile == HALFPLATECHOP)) {
             if(shade_color.a > 0.001f) {

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,7 @@ Template for new versions:
 - `stonesense`: added option ``EXTEND_TILES`` to slightly expand sprite to avoid gaps (on by default)
 - `stonesense`: added option ``PIXELPERFECT_ZOOM`` to change the zoom scale to avoid gaps (off by default)
 - `stonesense`: added back minecart track graphics
+- `stonesense`: designations in Stonesense now are tinted based on type, similar to DF
 
 ## Fixes
 - `stonesense`: fixed announcement text rendering off-screen with larger font sizes

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- `stonesense`: different types of dig designations (normal, blueprint, autodig) now are distinctly tinted, similar to the vanilla DF interface
 
 ## Removed
 
@@ -51,7 +52,6 @@ Template for new versions:
 - `stonesense`: added option ``EXTRUDE_TILES`` to slightly expand sprite to avoid gaps (on by default)
 - `stonesense`: added option ``PIXELPERFECT_ZOOM`` to change the zoom scale to avoid gaps (off by default)
 - `stonesense`: added back minecart track graphics
-- `stonesense`: designations in Stonesense now are tinted based on type, similar to DF
 
 ## Fixes
 - `stonesense`: fixed announcement text rendering off-screen with larger font sizes


### PR DESCRIPTION
Fixes: https://github.com/DFHack/stonesense/issues/183
![image](https://github.com/user-attachments/assets/0d5b6ee9-02cb-4fc5-a629-254343ebca66)
