### PR TITLE
Clairify the designation tints better (and fix typo)

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -43,7 +43,7 @@ Template for new versions:
 - `stonesense`: megashots no longer leave stonesense unresponsive
 
 ## Misc Improvements
-- `stonesense`: different types of dig designations (normal, blueprint, autodig) now have distinctly colors, matching the vanilla DF interface
+- `stonesense`: different types of dig-mode designations (normal, autodig, and the blueprint variants of both) now have distinct colors that more closely match the vanilla DF interface
 
 ## Removed
 - `stonesense`: removed the "follow DF cursor" tracking mode since the keyboard cursor is no longer commonly used for moving the map around


### PR DESCRIPTION
- "Dig-mode" bc its not just mining, its stairs and the like too.
- "More closely match" bc we show differences between a blueprint and an autodig turned blueprint.
- "Distinct colors" not distinctly