### PR TITLE
remove use of DFHack `Materials` module for raws

### DIFF
--- a/ContentLoader.cpp
+++ b/ContentLoader.cpp
@@ -72,8 +72,6 @@ bool ContentLoader::Load()
     shrubConfigs.clear();
     flushImgFiles();
 
-    auto& ssConfig = stonesenseState.ssConfig;
-
     draw_loading_message("Reading Custom Workshop Types");
     DFHack::Buildings::ReadCustomWorkshopTypes(custom_workshop_types);
     draw_loading_message("Reading Professions");

--- a/ContentLoader.cpp
+++ b/ContentLoader.cpp
@@ -15,6 +15,7 @@
 
 #include "df/caste_raw.h"
 #include "df/creature_raw.h"
+#include "df/descriptor_color.h"
 #include "df/entity_position.h"
 #include "df/entity_position_raw.h"
 #include "df/entity_raw.h"
@@ -71,60 +72,8 @@ bool ContentLoader::Load()
     shrubConfigs.clear();
     flushImgFiles();
 
-    // This is an extra suspend/resume, but it only happens when reloading the config
-    // ie not enough to worry about
-    //DF.Suspend();
-    ////read data from DF
-    //const vector<string> *tempClasses = DF.getMemoryInfo()->getClassIDMapping();
-    //// make a copy for our use
-    //classIdStrings = *tempClasses;
-
-    try {
-        Mats = DFHack::Core::getInstance().getMaterials();
-    } catch(exception &e) {
-        LogError("DFhack exeption: %s\n", e.what());
-    }
     auto& ssConfig = stonesenseState.ssConfig;
-    draw_loading_message("Reading Creature Names");
-    if (!ssConfig.skipCreatureTypes) {
-        try {
-            Mats->ReadCreatureTypes();
-        } catch(exception &e) {
-            LogError("DFhack exeption: %s\n", e.what());
-            ssConfig.skipCreatureTypes = true;
-        }
-    }
-    if(!ssConfig.skipCreatureTypesEx) {
-        try {
-            Mats->ReadCreatureTypesEx();
-        } catch(exception &e) {
-            LogError("DFhack exeption: %s\n", e.what());
-            ssConfig.skipCreatureTypesEx = true;
-        }
-    }
-    draw_loading_message("Reading Color Descriptors");
-    if (!ssConfig.skipDescriptorColors) {
-        try {
-            Mats->ReadDescriptorColors();
-        } catch(exception &e) {
-            LogError("DFhack exeption: %s\n", e.what());
-            ssConfig.skipDescriptorColors = true;
-        }
-    }
-    draw_loading_message("Reading Inorganic Materials");
-    if (!ssConfig.skipInorganicMats) {
-        if(!Mats->CopyInorganicMaterials(this->inorganic)) {
-            LogError("Missing inorganic materials!\n");
-            ssConfig.skipInorganicMats = true;
-        }
-    }
-    draw_loading_message("Reading Organic Materials");
-    if (!ssConfig.skipOrganicMats) {
-        if(!Mats->CopyOrganicMaterials(this->organic)) {
-            LogError("Missing organic materials!\n");
-            ssConfig.skipOrganicMats = true;
-        }
-    }
+
     draw_loading_message("Reading Custom Workshop Types");
     DFHack::Buildings::ReadCustomWorkshopTypes(custom_workshop_types);
     draw_loading_message("Reading Professions");
@@ -478,15 +427,15 @@ int lookupMaterialIndex(int matType, const char* strValue)
 
     // for appropriate elements, look up subtype
     if (matType == INORGANIC && !ssConfig.skipInorganicMats) {
-        return lookupIndexedType(strValue,contentLoader->inorganic);
+        return lookupIndexedType(strValue, contentLoader->inorganic);
     } else if (matType == WOOD && !ssConfig.skipOrganicMats) {
-        return lookupIndexedType(strValue,contentLoader->organic);
+        return lookupIndexedType(strValue, contentLoader->organic);
     } else if (matType == PLANT && !ssConfig.skipOrganicMats) {
-        return lookupIndexedType(strValue,contentLoader->organic);
+        return lookupIndexedType(strValue, contentLoader->organic);
     } else if (matType == PLANTCLOTH && !ssConfig.skipOrganicMats) {
-        return lookupIndexedType(strValue,contentLoader->organic);
+        return lookupIndexedType(strValue, contentLoader->organic);
     } else if (matType == LEATHER && !ssConfig.skipCreatureTypes) {
-        return lookupIndexedType(strValue,contentLoader->Mats->race);
+        return lookupIndexedType(strValue, df::global::world->raws.creatures.all, &df::creature_raw::creature_id);
     } else {
         //maybe allow some more in later
         return INVALID_INDEX;
@@ -620,7 +569,7 @@ const char *lookupMaterialName(int matType,int matIndex)
         typeVector=&(contentLoader->organic);
     } else if (matType == LEATHER) {
         if(!ssConfig.skipCreatureTypes) {
-            typeVector=&(contentLoader->Mats->race);
+            return (df::global::world->raws.creatures.all)[matIndex]->creature_id.c_str();
         } else {
             return NULL;
         }
@@ -763,10 +712,13 @@ ALLEGRO_COLOR lookupMaterialColor(int matType, int matIndex, int dyeType, int dy
     ALLEGRO_COLOR dyeColor = al_map_rgb(255,255,255);
     DFHack::MaterialInfo dye;
     if (dyeType >= 0 && dyeIndex >= 0 && dye.decode(dyeType, dyeIndex))
-        dyeColor = al_map_rgb_f(
-        contentLoader->Mats->color[dye.material->powder_dye].red,
-        contentLoader->Mats->color[dye.material->powder_dye].green,
-        contentLoader->Mats->color[dye.material->powder_dye].blue);
+    {
+        if (dye.material->powder_dye != -1)
+        {
+            auto cd = df::global::world->raws.descriptors.colors[dye.material->powder_dye];
+            dyeColor = al_map_rgb_f(cd->red, cd->green, cd->blue);
+        }
+    }
     // FIXME integer truncation: matType should not be an int
     DFHack::t_matglossPair matPair{ int16_t(matType), matIndex };
     if (ALLEGRO_COLOR * matResult = contentLoader->materialColorConfigs.get(matPair))
@@ -793,10 +745,8 @@ ALLEGRO_COLOR lookupMaterialColor(int matType, int matIndex, int dyeType, int dy
 DFColor:
     DFHack::MaterialInfo mat;
     if(mat.decode(matType, matIndex)) {
-            return al_map_rgb_f(
-                       contentLoader->Mats->color[mat.material->state_color[0]].red,
-                       contentLoader->Mats->color[mat.material->state_color[0]].green,
-                       contentLoader->Mats->color[mat.material->state_color[0]].blue) * dyeColor;
+        auto cd = df::global::world->raws.descriptors.colors[mat.material->state_color[0]];
+        return al_map_rgb_f(cd->red, cd->green, cd->blue) * dyeColor;
     }
     return defaultColor * dyeColor;
 }

--- a/ContentLoader.h
+++ b/ContentLoader.h
@@ -131,7 +131,6 @@ public:
 
     std::vector<std::string> professionStrings;
     std::map <uint32_t, std::string> custom_workshop_types;
-    DFHack::Materials* Mats = nullptr;
     std::vector<DFHack::t_matgloss> organic;
     std::vector<DFHack::t_matglossInorganic> inorganic;
 
@@ -159,21 +158,21 @@ extern int loadImgFromXML(TiXmlElement* elemRoot);
 MAT_BASICS lookupMaterialType(const char* strValue);
 int lookupMaterialIndex(int matType, const char* strValue);
 
-template <typename T, typename Index = decltype(T::id)>
-int lookupIndexedType(const Index& indexName, const std::vector<T>& typeVector)
+template <typename T, typename U = T>
+int lookupIndexedType(std::string_view indexName, const std::vector<T>& typeVector, std::string U::* fld = &T::id)
 {
-    auto get_id = [](auto tv) {
-        if constexpr (std::is_pointer_v<T>) return tv->id;
-        else return tv.id;
+    auto get_id = [fld](auto tv) {
+        if constexpr (std::is_pointer_v<T>) return tv->*fld;
+        else return tv.*fld;
         };
     auto it = std::find_if(typeVector.begin(), typeVector.end(),
         [&](auto tv) -> bool { return get_id(tv) == indexName; });
     return it != typeVector.end() ? it - typeVector.begin() : INVALID_INDEX;
 }
-template <typename T, typename Index = decltype(T::id)>
-int lookupIndexedPointerType(const Index& indexName, const std::vector<T*>& typeVector)
+template <typename T>
+int lookupIndexedPointerType(std::string_view indexName, const std::vector<T*>& typeVector, std::string T::* fld = &T::id)
 {
-    return lookupIndexedType<T*, Index>(indexName, typeVector);
+    return lookupIndexedType<T*, T>(indexName, typeVector, fld);
 }
 
 const char *lookupMaterialTypeName(int matType);

--- a/CreatureConfiguration.cpp
+++ b/CreatureConfiguration.cpp
@@ -40,8 +40,8 @@ namespace {
                 //resize using hint from creature name list
                 size_t newsize = size_t(gameID) + 1;
                 auto& contentLoader = stonesenseState.contentLoader;
-                if (newsize <= contentLoader->Mats->race.size()) {
-                    newsize = contentLoader->Mats->race.size() + 1;
+                if (newsize <= df::global::world->raws.creatures.all.size()) {
+                    newsize = df::global::world->raws.creatures.all.size() + 1;
                 }
                 while (knownCreatures.size() < newsize) {
                     knownCreatures.push_back(nullptr);
@@ -64,7 +64,7 @@ namespace {
             return false;
         }
         auto& contentLoader = stonesenseState.contentLoader;
-        int gameID = lookupIndexedType(elemCreature->Attribute("gameID"), contentLoader->Mats->race);
+        int gameID = lookupIndexedType(elemCreature->Attribute("gameID"), df::global::world->raws.creatures.all, &df::creature_raw::creature_id);
         if (gameID == INVALID_INDEX) {
             return false;
         }
@@ -118,7 +118,7 @@ namespace {
             int caste = -1;
             const char* caststr = elemVariant->Attribute("caste");
             if (caststr != NULL && caststr[0] != 0) {
-                caste = lookupIndexedType(caststr, contentLoader->Mats->raceEx[gameID].castes);
+                caste = lookupIndexedType(caststr, df::global::world->raws.creatures.all[gameID]->caste, &df::caste_raw::caste_id);
             }
             const char* specstr = elemVariant->Attribute("special");
             enumCreatureSpecialCases crespec = eCSC_Any;

--- a/CreatureConfiguration.cpp
+++ b/CreatureConfiguration.cpp
@@ -39,7 +39,6 @@ namespace {
             if (knownCreatures.size() <= size_t(gameID)) {
                 //resize using hint from creature name list
                 size_t newsize = size_t(gameID) + 1;
-                auto& contentLoader = stonesenseState.contentLoader;
                 if (newsize <= df::global::world->raws.creatures.all.size()) {
                     newsize = df::global::world->raws.creatures.all.size() + 1;
                 }
@@ -63,7 +62,6 @@ namespace {
         if (ssConfig.skipCreatureTypes) {
             return false;
         }
-        auto& contentLoader = stonesenseState.contentLoader;
         int gameID = lookupIndexedType(elemCreature->Attribute("gameID"), df::global::world->raws.creatures.all, &df::creature_raw::creature_id);
         if (gameID == INVALID_INDEX) {
             return false;

--- a/GUI.cpp
+++ b/GUI.cpp
@@ -30,6 +30,7 @@
 #include "df/plotinfost.h"
 #include "df/building_actual.h"
 #include "df/world.h"
+#include "df/descriptor_color.h"
 
 #include "df/itemdef.h"
 #include "df/itemdef_weaponst.h"
@@ -644,7 +645,8 @@ namespace
             mat.decode(b->material.type, b->material.index);
             if (mat.isValid())
             {
-                ALLEGRO_COLOR color = al_map_rgb_f(contentLoader->Mats->color[mat.material->state_color[0]].red, contentLoader->Mats->color[mat.material->state_color[0]].green, contentLoader->Mats->color[mat.material->state_color[0]].blue);
+                auto cd = df::global::world->raws.descriptors.colors[mat.material->state_color[0]];
+                ALLEGRO_COLOR color = al_map_rgb_f(cd->red, cd->green, cd->blue);
                 draw_textf_border(font, color, 2, (i++ * fontHeight), 0,
                     "%s", mat.material->state_name[0].c_str());
             }

--- a/SpriteObjects.cpp
+++ b/SpriteObjects.cpp
@@ -10,6 +10,8 @@
 #include "GameConfiguration.h"
 #include "StonesenseState.h"
 
+#include "df/color_modifier_raw.h"
+#include "df/descriptor_color.h"
 #include "df/descriptor_pattern.h"
 #include "df/itemdef_ammost.h"
 #include "df/itemdef_armorst.h"
@@ -338,16 +340,16 @@ void c_sprite::set_by_xml(TiXmlElement *elemSprite, int32_t inFile, int32_t crea
     const char* bodyPartStr = elemSprite->Attribute("bodypart");
     //copy new, if found
     if (bodyPartStr != NULL && bodyPartStr[0] != 0) {
-        DFHack::t_creaturecaste & caste = contentLoader->Mats->raceEx[creatureID].castes[(casteID==INVALID_INDEX) ? 0 : casteID];
-        std::vector<DFHack::t_colormodifier> & colormods = caste.ColorModifier;
+        auto& caste = df::global::world->raws.creatures.all[creatureID]->caste[(casteID == INVALID_INDEX) ? 0 : casteID];
+        auto& colormods = caste->color_modifiers;
         for(size_t j = 0; j<colormods.size() ; j++) {
-            if(colormods[j].part == bodyPartStr) {
+            if(colormods[j]->part == bodyPartStr) {
                 caste_bodypart_index = j;
                 return;
             }
         }
         LogError("Failed loading bodypart '%s' of creature '%s' with caste '%s' from xml.",
-            bodyPartStr, contentLoader->Mats->raceEx[creatureID].id.c_str(), caste.id.c_str());
+            bodyPartStr, df::global::world->raws.creatures.all[creatureID]->creature_id.c_str(), caste->caste_id.c_str());
     }
 
     subsprites.clear();
@@ -643,9 +645,9 @@ void c_sprite::set_by_xml(TiXmlElement *elemSprite)
         namedcolor=al_map_rgb(255, 255, 255);
     } else {
         auto& contentLoader = stonesenseState.contentLoader;
-        int colorindex = lookupIndexedType(namedColorStr, contentLoader->Mats->color);
-        DFHack::t_descriptor_color col = contentLoader->Mats->color[colorindex];
-        namedcolor = al_map_rgb_f( col.red, col.green, col.blue);
+        int colorindex = lookupIndexedType(namedColorStr, df::global::world->raws.descriptors.colors, &df::descriptor_color::id);
+        auto& col = df::global::world->raws.descriptors.colors[colorindex];
+        namedcolor = al_map_rgb_f( col->red, col->green, col->blue);
     }
 
     //Should the sprite be shown only when there is snow?
@@ -1147,7 +1149,7 @@ ALLEGRO_COLOR c_sprite::get_color(void* tile)
     auto& ssConfig = stonesenseState.ssConfig;
 
     Tile * b = (Tile *) tile;
-    uint32_t dayofLife = 0;
+    int32_t dayofLife = 0;
     switch(shadeBy) {
     case ShadeNone:
         return al_map_rgb(255, 255, 255);
@@ -1194,28 +1196,28 @@ ALLEGRO_COLOR c_sprite::get_color(void* tile)
         if(b->occ.bits.unit && b->creature) {
             dayofLife = b->creature->origin->birth_year*12*28 + b->creature->origin->birth_time/1200;
             if((!ssConfig.skipCreatureTypes) && (!ssConfig.skipCreatureTypesEx) && (!ssConfig.skipDescriptorColors)) {
-                DFHack::t_creaturecaste & caste = contentLoader->Mats->raceEx[b->creature->origin->race].castes[b->creature->origin->caste];
-                std::vector<DFHack::t_colormodifier> & colormods =caste.ColorModifier;
+                auto& caste = df::global::world->raws.creatures.all[b->creature->origin->race]->caste[b->creature->origin->caste];
+                auto& colormods = caste->color_modifiers;
                 if(caste_bodypart_index != INVALID_INDEX && size_t(caste_bodypart_index) < colormods.size()){
-                    DFHack::t_colormodifier & colormod = colormods[caste_bodypart_index];
-                    if(colormod.colorlist.size() > b->creature->color[caste_bodypart_index]) {
-                        uint32_t cr_color = colormod.colorlist.at(b->creature->color[caste_bodypart_index]);
+                    auto& colormod = colormods[caste_bodypart_index];
+                    if(colormod->pattern_index.size() > b->creature->color[caste_bodypart_index]) {
+                        uint32_t cr_color = colormod->pattern_index.at(b->creature->color[caste_bodypart_index]);
                         if(cr_color < df::global::world->raws.descriptors.patterns.size()) {
                             uint16_t actual_color = df::global::world->raws.descriptors.patterns[cr_color]->colors[pattern_index%df::global::world->raws.descriptors.patterns[cr_color]->colors.size()];
-                            if(actual_color < contentLoader->Mats->color.size()){
-                                if(colormod.startdate > 0) {
-                                    if((colormod.startdate <= dayofLife) &&
-                                        (colormod.enddate > dayofLife)) {
+                            if(actual_color < df::global::world->raws.descriptors.colors.size()){
+                                if(colormod->start_date > 0) {
+                                    if((colormod->start_date <= dayofLife) &&
+                                        (colormod->end_date > dayofLife)) {
                                             return al_map_rgb_f(
-                                                contentLoader->Mats->color[actual_color].red,
-                                                contentLoader->Mats->color[actual_color].green,
-                                                contentLoader->Mats->color[actual_color].blue);;
+                                                df::global::world->raws.descriptors.colors[actual_color]->red,
+                                                df::global::world->raws.descriptors.colors[actual_color]->green,
+                                                df::global::world->raws.descriptors.colors[actual_color]->blue);;
                                     }
                                 } else
                                     return al_map_rgb_f(
-                                    contentLoader->Mats->color[actual_color].red,
-                                    contentLoader->Mats->color[actual_color].green,
-                                    contentLoader->Mats->color[actual_color].blue);
+                                    df::global::world->raws.descriptors.colors[actual_color]->red,
+                                    df::global::world->raws.descriptors.colors[actual_color]->green,
+                                    df::global::world->raws.descriptors.colors[actual_color]->blue);
                             }
                         }
                     }

--- a/SpriteObjects.cpp
+++ b/SpriteObjects.cpp
@@ -332,7 +332,6 @@ c_sprite::~c_sprite(void)
 
 void c_sprite::set_by_xml(TiXmlElement *elemSprite, int32_t inFile, int32_t creatureID, int32_t casteID)
 {
-    auto& contentLoader = stonesenseState.contentLoader;
     fileindex = inFile;
     set_by_xml(elemSprite);
 
@@ -644,7 +643,6 @@ void c_sprite::set_by_xml(TiXmlElement *elemSprite)
     if (namedColorStr == NULL || namedColorStr[0] == 0) {
         namedcolor=al_map_rgb(255, 255, 255);
     } else {
-        auto& contentLoader = stonesenseState.contentLoader;
         int colorindex = lookupIndexedType(namedColorStr, df::global::world->raws.descriptors.colors, &df::descriptor_color::id);
         auto& col = df::global::world->raws.descriptors.colors[colorindex];
         namedcolor = al_map_rgb_f( col->red, col->green, col->blue);
@@ -1145,9 +1143,7 @@ void c_sprite::set_plate_layout(uint8_t layout)
 
 ALLEGRO_COLOR c_sprite::get_color(void* tile)
 {
-    auto& contentLoader = stonesenseState.contentLoader;
     auto& ssConfig = stonesenseState.ssConfig;
-
     Tile * b = (Tile *) tile;
     int32_t dayofLife = 0;
     switch(shadeBy) {


### PR DESCRIPTION
read directly from DF memory instead

using the `Materials` module made sense when `stonesense` was out of process, but this hasn't been the case in over a decade
