### PR TITLE
Fix segfault in lookupMaterialColor from unbounded color index

### DIFF
--- a/ContentLoader.cpp
+++ b/ContentLoader.cpp
@@ -743,8 +743,11 @@ ALLEGRO_COLOR lookupMaterialColor(int matType, int matIndex, int dyeType, int dy
 DFColor:
     DFHack::MaterialInfo mat;
     if(mat.decode(matType, matIndex)) {
-        auto cd = df::global::world->raws.descriptors.colors[mat.material->state_color[0]];
-        return al_map_rgb_f(cd->red, cd->green, cd->blue) * dyeColor;
+        int16_t colorIdx = mat.material->state_color[0];
+        if (colorIdx >= 0 && size_t(colorIdx) < df::global::world->raws.descriptors.colors.size()) {
+            auto cd = df::global::world->raws.descriptors.colors[colorIdx];
+            return al_map_rgb_f(cd->red, cd->green, cd->blue) * dyeColor;
+        }
     }
     return defaultColor * dyeColor;
 }

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `stonesense`: fixed a crash when rendering materials with an out-of-range color index
 
 ## Misc Improvements
 


### PR DESCRIPTION
Fixes a segfault in lookupMaterialColor caused by an unbounded array index
state_color[0] was used directly as an index into descriptors.colors without checking whether it was in range. For materials with an invalid or out-of-range color index (reproduced with an inorganic material, matIndex=307), this caused a segfault instead of falling back gracefully.
This adds a bounds check before dereferencing, falling back to defaultColor — consistent with the fallback behavior already used elsewhere in this same function — when the index is invalid.
Reproduced via gdb backtrace:
Thread 21 "dwarfort" received signal SIGSEGV, Segmentation fault.
lookupMaterialColor (matType=0, matIndex=307, ...) at ContentLoader.cpp:710
710      return al_map_rgb_f(cd->red, cd->green, cd->blue) * dyeColor;